### PR TITLE
Fix issue with PBM files whose width is a multiple of 8, and add a missing include

### DIFF
--- a/pnm.hpp
+++ b/pnm.hpp
@@ -1246,6 +1246,7 @@ image<bit_pixel, Alloc> read_pbm_binary(const std::string& fname)
             img(i*8 + 6, j) = bit_pixel((v & 0x02) == 0x02);
             img(i*8 + 7, j) = bit_pixel((v & 0x01) == 0x01);
         }
+        if (rem == 0) { continue; }
         std::uint8_t v(0);
         ifs.read(reinterpret_cast<char*>(&v), 1);
         for(std::size_t r=0; r<rem; ++r)

--- a/pnm.hpp
+++ b/pnm.hpp
@@ -30,6 +30,7 @@
 #error "pnm++ requires C++11 or later."
 #endif
 
+#include <cctype>
 #include <type_traits>
 #include <utility>
 #include <stdexcept>


### PR DESCRIPTION
see discussion in issue #2 

