### PR TITLE
Read/write binary files in binary mode

### DIFF
--- a/pnm.hpp
+++ b/pnm.hpp
@@ -1171,7 +1171,7 @@ template<typename Alloc = std::allocator<bit_pixel>>
 image<bit_pixel, Alloc> read_pbm_binary(const std::string& fname)
 {
     using detail::literals::operator"" _str;
-    std::ifstream ifs(fname);
+    std::ifstream ifs(fname, std::ios::binary);
     if(!ifs.good())
     {
         throw std::runtime_error(
@@ -1390,7 +1390,7 @@ template<typename Alloc = std::allocator<gray_pixel>>
 image<gray_pixel, Alloc> read_pgm_binary(const std::string& fname)
 {
     using detail::literals::operator"" _str;
-    std::ifstream ifs(fname);
+    std::ifstream ifs(fname, std::ios::binary);
     if(!ifs.good())
     {
         throw std::runtime_error(
@@ -1600,7 +1600,7 @@ template<typename Alloc = std::allocator<rgb_pixel>>
 image<rgb_pixel, Alloc> read_ppm_binary(const std::string& fname)
 {
     using detail::literals::operator"" _str;
-    std::ifstream ifs(fname);
+    std::ifstream ifs(fname, std::ios::binary);
     if(!ifs.good())
     {
         throw std::runtime_error(
@@ -1803,7 +1803,7 @@ template<typename Alloc>
 void write_pbm_binary(const std::string& fname,
                       const image<bit_pixel, Alloc>& img)
 {
-    std::ofstream ofs(fname);
+    std::ofstream ofs(fname, std::ios::binary);
     if(!ofs.good())
     {
         throw std::runtime_error(
@@ -1882,7 +1882,7 @@ template<typename Alloc>
 void write_pgm_binary(const std::string& fname,
                       const image<gray_pixel, Alloc>& img)
 {
-    std::ofstream ofs(fname);
+    std::ofstream ofs(fname, std::ios::binary);
     if(!ofs.good())
     {
         throw std::runtime_error(
@@ -1951,7 +1951,7 @@ template<typename Alloc>
 void write_ppm_binary(const std::string& fname,
                       const image<rgb_pixel, Alloc>& img)
 {
-    std::ofstream ofs(fname);
+    std::ofstream ofs(fname, std::ios::binary);
     if(!ofs.good())
     {
         throw std::runtime_error(


### PR DESCRIPTION
Here is another PR to fix issues I encountered on Windows. The UTests in `test_io.cpp` fail randomly on binary files on Windows, for two main reasons:

 - Writing a binary file without the mode `std::ios::binary` being set will insert eol sequence `\r\n` intead of `\n` which might not be interpreted correctly when reading back the file.
 - Reading a binary file without the mode `std::ios::binary` being set will end after reading byte `\x1A` (CTRL+Z) anywhere in the file. From `fopen` doc:

    > [On Windows] In text mode, CTRL+Z is interpreted as an EOF character on input.

    Here is an PBM file demonstrating that problem: [test_1a.zip](https://github.com/ToruNiina/pnm/files/6461531/test_1a.zip)

Setting the mode to `std::ios::binary` when reading/writing binary PPM, PBM, PGM files takes care of thoses issues.


