### PR TITLE
CMake: disable sample applications and tests by default, add interface library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,17 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.20)
 enable_testing()
 project(pnm++)
 
-include_directories(${PROJECT_SOURCE_DIR})
+add_library(pnm++ INTERFACE)
+target_include_directories(pnm++ INTERFACE ${PROJECT_SOURCE_DIR})
 
-add_subdirectory(sample)
-add_subdirectory(test)
+option(PNM_BUILD_SAMPLES "Builds the sample applications" OFF)
+option(PNM_BUILD_TEST "Builds the tests" OFF)
+
+if (PNM_BUILD_SAMPLES)
+    add_subdirectory(sample)
+endif ()
+
+if (PNM_BUILD_TEST)
+    add_subdirectory(test)
+endif ()

--- a/sample/CMakeLists.txt
+++ b/sample/CMakeLists.txt
@@ -4,6 +4,7 @@ set_target_properties(unicolor
     COMPILE_FLAGS "-std=c++11 -O2 -Wall -Wpedantic -Wextra"
     RUNTIME_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR}/sample
 )
+target_link_libraries(unicolor PRIVATE pnm++)
 
 add_executable(mandelbrot mandelbrot.cpp)
 set_target_properties(mandelbrot
@@ -11,3 +12,4 @@ set_target_properties(mandelbrot
     COMPILE_FLAGS "-std=c++11 -O2 -Wall -Wpedantic -Wextra"
     RUNTIME_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR}/sample
 )
+target_link_libraries(mandelbrot PRIVATE pnm++)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -19,4 +19,5 @@ foreach(TEST_NAME ${TEST_NAMES})
                           COMPILE_FLAGS "-std=c++11 -O2 -Wall -Wpedantic -Wextra")
     add_test(NAME ${TEST_NAME} COMMAND ${TEST_NAME}
              WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/test")
+    target_link_libraries(${TEST_NAME} PRIVATE pnm++)
 endforeach(TEST_NAME)


### PR DESCRIPTION
When integrating this library via CMakle with [CPM](https://github.com/cpm-cmake/CPM.cmake) into an existing project, additional steps have to be taken to use this library (i.e. specifying the include directory manually). Also the sample and test targets will be visible in the host CMake project, which is typically not wanted.

To simplify using the library this PR adds an interface library which can easily be consumed by users without the need for tampering with the include directories manually.
Test and sample projects will only be built when the given option is enabled (which is `OFF` by default).