### PR TITLE
fix line_proxy and const_line_proxy

### DIFF
--- a/pnm.hpp
+++ b/pnm.hpp
@@ -420,22 +420,22 @@ struct line_proxy
     bool operator<(const line_proxy& rhs) const noexcept
     {
         return this->nx_ == rhs.nx_ && this->container_ == rhs.container_ &&
-               this->iy_ <  rhs.ny_;
+               this->iy_ <  rhs.iy_;
     }
     bool operator>(const line_proxy& rhs) const noexcept
     {
         return this->nx_ == rhs.nx_ && this->container_ == rhs.container_ &&
-               this->iy_ >  rhs.ny_;
+               this->iy_ >  rhs.iy_;
     }
     bool operator<=(const line_proxy& rhs) const noexcept
     {
         return this->nx_ == rhs.nx_ && this->container_ == rhs.container_ &&
-               this->iy_ <= rhs.ny_;
+               this->iy_ <= rhs.iy_;
     }
     bool operator>=(const line_proxy& rhs) const noexcept
     {
         return this->nx_ == rhs.nx_ && this->container_ == rhs.container_ &&
-               this->iy_ >= rhs.ny_;
+               this->iy_ >= rhs.iy_;
     }
 
   private:
@@ -509,22 +509,22 @@ struct const_line_proxy
     bool operator<(const const_line_proxy& rhs) const noexcept
     {
         return this->nx_ == rhs.nx_ && this->container_ == rhs.container_ &&
-               this->iy_ <  rhs.ny_;
+               this->iy_ <  rhs.iy_;
     }
     bool operator>(const const_line_proxy& rhs) const noexcept
     {
         return this->nx_ == rhs.nx_ && this->container_ == rhs.container_ &&
-               this->iy_ >  rhs.ny_;
+               this->iy_ >  rhs.iy_;
     }
     bool operator<=(const const_line_proxy& rhs) const noexcept
     {
         return this->nx_ == rhs.nx_ && this->container_ == rhs.container_ &&
-               this->iy_ <= rhs.ny_;
+               this->iy_ <= rhs.iy_;
     }
     bool operator>=(const const_line_proxy& rhs) const noexcept
     {
         return this->nx_ == rhs.nx_ && this->container_ == rhs.container_ &&
-               this->iy_ >= rhs.ny_;
+               this->iy_ >= rhs.iy_;
     }
 
   private:


### PR DESCRIPTION
This fixes an issue in the code, that did compile until recently, but now fails with recent emscripten (and likely recent clang versions): See example of failing compilations here:
https://github.com/pthom/imgui_bundle/actions/runs/9171248130/job/25215170498